### PR TITLE
Pass empty list if there is no category id

### DIFF
--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -129,8 +129,10 @@ class BlogViews:
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
             page=page,
-            groups=[group.get("id", "")],
-            categories=[category.get("id", "")],
+            groups=[group.get("id")] if group.get("id", None) else [],
+            categories=[category.get("id")]
+            if category.get("id", None)
+            else [],
         )
 
         return {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.4.0",
+    version="6.4.1",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
WordPress API returns 400 if return list with empty string, because it treats it as a Truly parameter. Instead we should pass an empty list, which will be accepted as Falsy in the case there is no id for the category.

## QA

Go to https://ubuntu-com-13283.demos.haus/blog?page=2, check that it doesn't break anymore https://ubuntu.com/blog?page=2

Go to https://ubuntu-com-13283.demos.haus/blog?page=500, check that it return 404 now (exceeded max num of pages)


or 
- Pull down and checkout this PR
- Locally change `requirements.txt` of ubuntu.com project to: 
```
canonicalwebteam.blog @ git+https://github.com/canonical/canonicalwebteam.blog@fix-blog-paginated-page-wd-6988`
```
- Run `dotrun clean && dotrun`
- Go to http://0.0.0.0:8001/blog?page=2
- Go to http://0.0.0.0:8001/blog?page=500


## Issues
Fixes https://github.com/canonical/canonicalwebteam.blog/issues/158
Fixes https://warthogs.atlassian.net/browse/WD-6988