### PR TITLE
Fix blog posts not showing up on u.com/blog

### DIFF
--- a/canonicalwebteam/blog/wordpress.py
+++ b/canonicalwebteam/blog/wordpress.py
@@ -35,7 +35,7 @@ class Wordpress:
                 else:
                     clean_params[key] = value
 
-        query = urlencode({**clean_params, "_embed": "true"})
+        query = urlencode({**clean_params, "_embed": ""})
 
         response = self.session.request(
             method, f"{self.api_url}/{endpoint}?{query}"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.4.1",
+    version="6.4.2",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/cassettes/TestBlogAPI.test_get_articles.yaml
+++ b/tests/cassettes/TestBlogAPI.test_get_articles.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=
   response:
     body:
       string: '[{"id":97100,"date":"2020-07-14T04:09:36","date_gmt":"2020-07-14T04:09:36","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97100"},"modified":"2020-07-14T04:09:38","modified_gmt":"2020-07-14T04:09:38","slug":"microk8s-ha-tech-preview-is-now-available-2","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/07\/14\/microk8s-ha-tech-preview-is-now-available-2\/","title":{"rendered":"MicroK8s\u73b0\u8fce\u6765\u6280\u672f\u9884\u89c8\u7248HA\u529f\u80fd"},"content":{"rendered":"\n<p>\u8f7b\u91cf\u7ea7\u7684Kubernetes
@@ -1182,7 +1182,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=100
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -1221,7 +1221,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=nonexistent-slug&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=nonexistent-slug&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlogAPI.test_get_articles_with_transforming_links.yaml
+++ b/tests/cassettes/TestBlogAPI.test_get_articles_with_transforming_links.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=
   response:
     body:
       string: '[{"id":96510,"date":"2020-06-23T12:00:27","date_gmt":"2020-06-23T12:00:27","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96510"},"modified":"2020-06-23T12:00:02","modified_gmt":"2020-06-23T12:00:02","slug":"dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/23\/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available\/","title":{"rendered":"Dell

--- a/tests/cassettes/TestBlogAPI.test_get_articles_without_transforming_links.yaml
+++ b/tests/cassettes/TestBlogAPI.test_get_articles_without_transforming_links.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=
   response:
     body:
       string: '[{"id":96510,"date":"2020-06-23T12:00:27","date_gmt":"2020-06-23T12:00:27","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96510"},"modified":"2020-06-23T12:00:02","modified_gmt":"2020-06-23T12:00:02","slug":"dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/23\/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available\/","title":{"rendered":"Dell

--- a/tests/cassettes/TestBlogAPI.test_get_thumbnail_setting.yaml
+++ b/tests/cassettes/TestBlogAPI.test_get_thumbnail_setting.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=
   response:
     body:
       string: '[{"id":96510,"date":"2020-06-23T12:00:27","date_gmt":"2020-06-23T12:00:27","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96510"},"modified":"2020-06-23T12:00:02","modified_gmt":"2020-06-23T12:00:02","slug":"dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/23\/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available\/","title":{"rendered":"Dell

--- a/tests/cassettes/TestBlogAPI.test_it_does_not_transform_article_image.yaml
+++ b/tests/cassettes/TestBlogAPI.test_it_does_not_transform_article_image.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=
   response:
     body:
       string: '[{"id":96510,"date":"2020-06-23T12:00:27","date_gmt":"2020-06-23T12:00:27","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96510"},"modified":"2020-06-23T12:00:02","modified_gmt":"2020-06-23T12:00:02","slug":"dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/23\/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available\/","title":{"rendered":"Dell

--- a/tests/cassettes/TestBlogAPI.test_it_transforms_article_image.yaml
+++ b/tests/cassettes/TestBlogAPI.test_it_transforms_article_image.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=
   response:
     body:
       string: '[{"id":96510,"date":"2020-06-23T12:00:27","date_gmt":"2020-06-23T12:00:27","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96510"},"modified":"2020-06-23T12:00:02","modified_gmt":"2020-06-23T12:00:02","slug":"dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/23\/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available\/","title":{"rendered":"Dell

--- a/tests/cassettes/TestBlogAPI.test_it_transforms_article_with_fixed_dimensions_image.yaml
+++ b/tests/cassettes/TestBlogAPI.test_it_transforms_article_with_fixed_dimensions_image.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdesign-and-web-team-summary-20th-july-2020&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Fdesign-and-web-team-summary-20th-july-2020&_embed=
   response:
     body:
       string: '[{"id":97160,"date":"2020-07-20T17:48:22","date_gmt":"2020-07-20T17:48:22","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97160"},"modified":"2020-07-20T22:34:39","modified_gmt":"2020-07-20T22:34:39","slug":"design-and-web-team-summary-20th-july-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/07\/20\/design-and-web-team-summary-20th-july-2020\/","title":{"rendered":"Design

--- a/tests/cassettes/TestBlogAPI.test_it_transforms_article_with_percent_width_dimension_image.yaml
+++ b/tests/cassettes/TestBlogAPI.test_it_transforms_article_with_percent_width_dimension_image.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Ftop-10-linux-apps-for-entertainment-and-leisure&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=%2Ftop-10-linux-apps-for-entertainment-and-leisure&_embed=
   response:
     body:
       string: '[{"id":85990,"date":"2018-08-30T14:00:43","date_gmt":"2018-08-30T14:00:43","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=85990"},"modified":"2019-07-11T16:16:24","modified_gmt":"2019-07-11T16:16:24","slug":"top-10-linux-apps-for-entertainment-and-leisure","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2018\/08\/30\/top-10-linux-apps-for-entertainment-and-leisure\/","title":{"rendered":"Top

--- a/tests/cassettes/TestBlueprint.test_archive_int_year_month.yaml
+++ b/tests/cassettes/TestBlueprint.test_archive_int_year_month.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=phone-and-tablet&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=phone-and-tablet&_embed=
   response:
     body:
       string: '[{"id":1707,"count":1059,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/group\/phone-and-tablet\/","name":"Phone
@@ -72,7 +72,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&group=1707&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&group=1707&_embed=
   response:
     body:
       string: '[{"id":93663,"date":"2020-01-21T14:49:36","date_gmt":"2020-01-21T14:49:36","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=93663"},"modified":"2020-01-21T20:42:24","modified_gmt":"2020-01-21T20:42:24","slug":"anbox-cloud-disrupts-mobile-user-experience","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/01\/21\/anbox-cloud-disrupts-mobile-user-experience\/","title":{"rendered":"Anbox
@@ -711,7 +711,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=1707&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=1707&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_archives.yaml
+++ b/tests/cassettes/TestBlueprint.test_archives.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1333,7 +1333,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:21 GMT']
       Keep-Alive: ['timeout=5, max=100']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_article.yaml
+++ b/tests/cassettes/TestBlueprint.test_article.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=testing-your-user-contract&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=testing-your-user-contract&_embed=
   response:
     body:
       string: '[{"id":93920,"date":"2020-02-10T22:48:14","date_gmt":"2020-02-10T22:48:14","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=93920"},"modified":"2020-02-10T23:32:02","modified_gmt":"2020-02-10T23:32:02","slug":"testing-your-user-contract","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/02\/10\/testing-your-user-contract\/","title":{"rendered":"Testing
@@ -185,7 +185,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239%2C2598%2C2929&per_page=30&page=1&exclude=93920&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239%2C2598%2C2929&per_page=30&page=1&exclude=93920&_embed=
   response:
     body:
       string: '[{"id":103425,"date":"2021-07-08T07:21:55","date_gmt":"2021-07-08T07:21:55","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=103425"},"modified":"2021-07-08T08:48:29","modified_gmt":"2021-07-08T08:48:29","slug":"design-and-web-team-summary-2-july-2021","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/07\/08\/design-and-web-team-summary-2-july-2021\/","title":{"rendered":"Design
@@ -4491,7 +4491,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&tags%5B1%5D=2598&tags%5B2%5D=2929&per_page=30&page=2&exclude%5B0%5D=93920&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&tags%5B1%5D=2598&tags%5B2%5D=2929&per_page=30&page=2&exclude%5B0%5D=93920&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_article_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_article_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=not-exist&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlueprint.test_article_with_image.yaml
+++ b/tests/cassettes/TestBlueprint.test_article_with_image.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available&_embed=
   response:
     body:
       string: '[{"id":96510,"date":"2020-06-23T12:00:27","date_gmt":"2020-06-23T12:00:27","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96510"},"modified":"2020-10-05T13:06:26","modified_gmt":"2020-10-05T13:06:26","slug":"dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/23\/dell-xps-13-developer-edition-with-ubuntu-20-04-lts-pre-installed-is-now-available\/","title":{"rendered":"Dell
@@ -133,7 +133,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1235%2C2186%2C1301%2C3789&per_page=30&page=1&exclude=96510&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1235%2C2186%2C1301%2C3789&per_page=30&page=1&exclude=96510&_embed=
   response:
     body:
       string: '[{"id":102784,"date":"2021-05-14T10:22:28","date_gmt":"2021-05-14T10:22:28","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=102784"},"modified":"2021-05-14T10:22:30","modified_gmt":"2021-05-14T10:22:30","slug":"ubuntu-16-04-lts-esm-support-extended-maintenance","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/05\/14\/ubuntu-16-04-lts-esm-support-extended-maintenance\/","title":{"rendered":"Ubuntu
@@ -2627,7 +2627,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1235&tags%5B1%5D=2186&tags%5B2%5D=1301&tags%5B3%5D=3789&per_page=30&page=2&exclude%5B0%5D=96510&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1235&tags%5B1%5D=2186&tags%5B2%5D=1301&tags%5B3%5D=3789&per_page=30&page=2&exclude%5B0%5D=96510&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_article_with_relative_path_image.yaml
+++ b/tests/cassettes/TestBlueprint.test_article_with_relative_path_image.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=the-ubuntu-community-contributes-towards-saving-the-iberian-lynx&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=the-ubuntu-community-contributes-towards-saving-the-iberian-lynx&_embed=
   response:
     body:
       string: '[{"id":431,"date":"2010-10-07T17:28:29","date_gmt":"2010-10-07T16:28:29","guid":{"rendered":"http:\/\/blog.canonical.com\/?p=431"},"modified":"2019-07-12T08:34:12","modified_gmt":"2019-07-12T08:34:12","slug":"the-ubuntu-community-contributes-towards-saving-the-iberian-lynx","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2010\/10\/07\/the-ubuntu-community-contributes-towards-saving-the-iberian-lynx\/","title":{"rendered":"The
@@ -132,7 +132,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1216%2C2662%2C2705&per_page=30&page=1&exclude=431&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1216%2C2662%2C2705&per_page=30&page=1&exclude=431&_embed=
   response:
     body:
       string: '[{"id":103086,"date":"2021-06-17T19:23:57","date_gmt":"2021-06-17T19:23:57","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=103086"},"modified":"2021-06-17T19:23:58","modified_gmt":"2021-06-17T19:23:58","slug":"two-factor-authentication-coming-to-ubuntu-one","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/06\/17\/two-factor-authentication-coming-to-ubuntu-one\/","title":{"rendered":"Two-factor
@@ -1973,7 +1973,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1216&tags%5B1%5D=2662&tags%5B2%5D=2705&per_page=30&page=2&exclude%5B0%5D=431&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1216&tags%5B1%5D=2662&tags%5B2%5D=2705&per_page=30&page=2&exclude%5B0%5D=431&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_author.yaml
+++ b/tests/cassettes/TestBlueprint.test_author.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=nottrobin&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=nottrobin&_embed=
   response:
     body: {string: '[{"id":297,"name":"Robin Winslow","url":"https:\/\/login.ubuntu.com\/+id\/yEpy4tK","description":"","link":"https:\/\/admin.insights.ubuntu.com\/author\/nottrobin\/","slug":"nottrobin","avatar_urls":{"24":"https:\/\/secure.gravatar.com\/avatar\/72933f8d340100f493cfac7ca699cc62?s=24&d=mm&r=g","48":"https:\/\/secure.gravatar.com\/avatar\/72933f8d340100f493cfac7ca699cc62?s=48&d=mm&r=g","96":"https:\/\/secure.gravatar.com\/avatar\/72933f8d340100f493cfac7ca699cc62?s=96&d=mm&r=g"},"meta":[],"user_job_title":"","user_website_title":"","user_google":"","user_twitter":"","user_facebook":"","user_photo":"","user_location":"","_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users\/297"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users"}]}}]'}
     headers:
@@ -39,7 +39,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&author=297&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&author=297&_embed=
   response:
     body: {string: '[{"id":93596,"date":"2020-01-17T15:57:28","date_gmt":"2020-01-17T15:57:28","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=93596"},"modified":"2020-01-21T11:40:06","modified_gmt":"2020-01-21T11:40:06","slug":"design-and-web-team-summary-17-january-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/01\/17\/design-and-web-team-summary-17-january-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 17 January 2020"},"content":{"rendered":"\n<p>The
@@ -1570,7 +1570,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:23 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&author%5B0%5D=297&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&author%5B0%5D=297&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_author_feed.yaml
+++ b/tests/cassettes/TestBlueprint.test_author_feed.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=nottrobin&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=nottrobin&_embed=
   response:
     body: {string: '[{"id":297,"name":"Robin Winslow","url":"https:\/\/login.ubuntu.com\/+id\/yEpy4tK","description":"","link":"https:\/\/admin.insights.ubuntu.com\/author\/nottrobin\/","slug":"nottrobin","avatar_urls":{"24":"https:\/\/secure.gravatar.com\/avatar\/72933f8d340100f493cfac7ca699cc62?s=24&d=mm&r=g","48":"https:\/\/secure.gravatar.com\/avatar\/72933f8d340100f493cfac7ca699cc62?s=48&d=mm&r=g","96":"https:\/\/secure.gravatar.com\/avatar\/72933f8d340100f493cfac7ca699cc62?s=96&d=mm&r=g"},"meta":[],"user_job_title":"","user_website_title":"","user_google":"","user_twitter":"","user_facebook":"","user_photo":"","user_location":"","_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users\/297"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users"}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&author=297&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&author=297&_embed=
   response:
     body: {string: '[{"id":93596,"date":"2020-01-17T15:57:28","date_gmt":"2020-01-17T15:57:28","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=93596"},"modified":"2020-01-21T11:40:06","modified_gmt":"2020-01-21T11:40:06","slug":"design-and-web-team-summary-17-january-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/01\/17\/design-and-web-team-summary-17-january-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 17 January 2020"},"content":{"rendered":"\n<p>The
@@ -1572,7 +1572,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:23 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&author%5B0%5D=297&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&author%5B0%5D=297&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_author_feed_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_author_feed_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=not-exist&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlueprint.test_author_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_author_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=not-exist&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlueprint.test_category_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_category_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=not-exist&_embed=
   response:
     body:
       string: '[]'
@@ -69,7 +69,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=
   response:
     body:
       string: '[{"id":97853,"date":"2020-09-28T10:15:02","date_gmt":"2020-09-28T10:15:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97853"},"modified":"2020-09-28T10:15:04","modified_gmt":"2020-09-28T10:15:04","slug":"osm-hackfest-mr9","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/09\/28\/osm-hackfest-mr9\/","title":{"rendered":"Canonical
@@ -1426,7 +1426,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_events_and_webinars.yaml
+++ b/tests/cassettes/TestBlueprint.test_events_and_webinars.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=events&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=events&_embed=
   response:
     body: {string: '[{"id":1175,"count":130,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/events\/","name":"Events","slug":"events","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1175"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1175"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1175"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=webinars&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=webinars&_embed=
   response:
     body: {string: '[{"id":1187,"count":109,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/webinars\/","name":"Webinars","slug":"webinars","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1187"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1187"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1187"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -73,7 +73,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&categories=1175%2C1187&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&categories=1175%2C1187&_embed=
   response:
     body: {string: '[{"id":95012,"date":"2020-04-16T15:23:52","date_gmt":"2020-04-16T15:23:52","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=95012"},"modified":"2020-04-16T15:23:54","modified_gmt":"2020-04-16T15:23:54","slug":"you-are-invited-to-the-virtual-ubuntu-masters-event","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/04\/16\/you-are-invited-to-the-virtual-ubuntu-masters-event\/","title":{"rendered":"You
         are invited to the virtual Ubuntu Masters event"},"content":{"rendered":"\n<p>The
@@ -633,7 +633,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:25 GMT']
       Keep-Alive: ['timeout=5, max=98']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&categories%5B0%5D=1175&categories%5B1%5D=1187&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&categories%5B0%5D=1175&categories%5B1%5D=1187&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_feed.yaml
+++ b/tests/cassettes/TestBlueprint.test_feed.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1334,7 +1334,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:21 GMT']
       Keep-Alive: ['timeout=5, max=100']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_group.yaml
+++ b/tests/cassettes/TestBlueprint.test_group.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=design&_embed=
   response:
     body: {string: '[{"id":3407,"count":28,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/group\/design\/","name":"Design","slug":"design","taxonomy":"group","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group\/3407"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/group"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?group=3407"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/media?group=3407"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?group=3407"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -39,7 +39,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&categories=&group=3407&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&categories=&group=3407&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1735,7 +1735,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:28 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=3407&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=3407&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_group_feed.yaml
+++ b/tests/cassettes/TestBlueprint.test_group_feed.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=design&_embed=
   response:
     body: {string: '[{"id":3407,"count":28,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/group\/design\/","name":"Design","slug":"design","taxonomy":"group","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group\/3407"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/group"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?group=3407"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/media?group=3407"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?group=3407"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&group=3407&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&group=3407&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1736,7 +1736,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:30 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=3407&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=3407&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_group_feed_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_group_feed_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=not-exist&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlueprint.test_group_feed_works_with_image_without_src.yaml
+++ b/tests/cassettes/TestBlueprint.test_group_feed_works_with_image_without_src.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=phone-and-tablet&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=phone-and-tablet&_embed=
   response:
     body:
       string: '[{"id":1707,"count":1059,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/group\/phone-and-tablet\/","name":"Phone
@@ -70,7 +70,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&group=1707&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&group=1707&_embed=
   response:
     body:
       string: '[{"id":93663,"date":"2020-01-21T14:49:36","date_gmt":"2020-01-21T14:49:36","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=93663"},"modified":"2020-01-21T20:42:24","modified_gmt":"2020-01-21T20:42:24","slug":"anbox-cloud-disrupts-mobile-user-experience","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/01\/21\/anbox-cloud-disrupts-mobile-user-experience\/","title":{"rendered":"Anbox
@@ -709,7 +709,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=1707&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&group%5B0%5D=1707&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_group_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_group_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=not-exist&_embed=
   response:
     body:
       string: '[]'
@@ -69,7 +69,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&categories=&group=&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&categories=&group=&_embed=
   response:
     body:
       string: '[{"id":97853,"date":"2020-09-28T10:15:02","date_gmt":"2020-09-28T10:15:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97853"},"modified":"2020-09-28T10:15:04","modified_gmt":"2020-09-28T10:15:04","slug":"osm-hackfest-mr9","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/09\/28\/osm-hackfest-mr9\/","title":{"rendered":"Canonical
@@ -1426,7 +1426,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_homepage.yaml
+++ b/tests/cassettes/TestBlueprint.test_homepage.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&sticky=true&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&sticky=true&_embed=
   response:
     body:
       string: '[{"id":97114,"date":"2020-07-15T12:21:54","date_gmt":"2020-07-15T12:21:54","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97114"},"modified":"2020-07-15T12:21:55","modified_gmt":"2020-07-15T12:21:55","slug":"%ef%bb%bfcanonical-launches-enhanced-gsi-partner-programme-bringing-scalability-and-automation-to-modernise-enterprise-it-deployments","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/07\/15\/%ef%bb%bfcanonical-launches-enhanced-gsi-partner-programme-bringing-scalability-and-automation-to-modernise-enterprise-it-deployments\/","title":{"rendered":"\ufeffCanonical
@@ -399,7 +399,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=100
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&sticky=1&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&sticky=1&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -438,7 +438,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=events&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=events&_embed=
   response:
     body:
       string: '[{"id":1175,"count":131,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/events\/","name":"Events","slug":"events","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1175"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1175"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1175"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'
@@ -498,7 +498,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=webinars&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=webinars&_embed=
   response:
     body:
       string: '[{"id":1187,"count":110,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/webinars\/","name":"Webinars","slug":"webinars","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1187"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1187"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1187"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'
@@ -558,7 +558,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&categories=1175%2C1187&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&categories=1175%2C1187&_embed=
   response:
     body:
       string: '[{"id":96803,"date":"2020-06-29T19:15:13","date_gmt":"2020-06-29T19:15:13","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96803"},"modified":"2020-06-29T19:15:13","modified_gmt":"2020-06-29T19:15:13","slug":"data-centre-automation-for-hpc","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/29\/data-centre-automation-for-hpc\/","title":{"rendered":"Data
@@ -713,7 +713,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=97
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&categories%5B0%5D=1175&categories%5B1%5D=1187&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&categories%5B0%5D=1175&categories%5B1%5D=1187&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -752,7 +752,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&exclude=97114%2C96997%2C96510&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&exclude=97114%2C96997%2C96510&_embed=
   response:
     body:
       string: '[{"id":97111,"date":"2020-07-17T10:00:55","date_gmt":"2020-07-17T10:00:55","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97111"},"modified":"2020-07-16T06:59:42","modified_gmt":"2020-07-16T06:59:42","slug":"best-practices-for-an-effective-remote-team-in-the-world-of-cloud-delivery","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/07\/17\/best-practices-for-an-effective-remote-team-in-the-world-of-cloud-delivery\/","title":{"rendered":"Best
@@ -1694,7 +1694,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=96
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&exclude%5B0%5D=97114&exclude%5B1%5D=96997&exclude%5B2%5D=96510&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&exclude%5B0%5D=97114&exclude%5B1%5D=96997&exclude%5B2%5D=96510&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_latest_redirect.yaml
+++ b/tests/cassettes/TestBlueprint.test_latest_redirect.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&sticky=true&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&sticky=true&_embed=
   response:
     body:
       string: '[{"id":103322,"date":"2021-06-29T13:11:51","date_gmt":"2021-06-29T13:11:51","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=103322"},"modified":"2021-07-04T19:10:47","modified_gmt":"2021-07-04T19:10:47","slug":"canonical-global-survey-kubernetes-cloud-native","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/06\/29\/canonical-global-survey-kubernetes-cloud-native\/","title":{"rendered":"Kubernetes
@@ -325,7 +325,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=100
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&sticky=1&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&sticky=1&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -364,7 +364,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=events&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=events&_embed=
   response:
     body:
       string: '[{"id":1175,"count":133,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/events\/","name":"Events","slug":"events","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1175"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1175"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1175"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'
@@ -424,7 +424,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=webinars&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=webinars&_embed=
   response:
     body:
       string: '[{"id":1187,"count":110,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/webinars\/","name":"Webinars","slug":"webinars","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1187"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1187"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1187"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'
@@ -484,7 +484,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&categories=1175%2C1187&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=1&categories=1175%2C1187&_embed=
   response:
     body:
       string: '[{"id":101640,"date":"2021-03-04T10:19:08","date_gmt":"2021-03-04T10:19:08","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=101640"},"modified":"2021-03-04T10:19:10","modified_gmt":"2021-03-04T10:19:10","slug":"bosch-rexroth-on-ubuntu-core-at-embedded-world","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/03\/04\/bosch-rexroth-on-ubuntu-core-at-embedded-world\/","title":{"rendered":"Canonical
@@ -681,7 +681,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=97
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&categories%5B0%5D=1175&categories%5B1%5D=1187&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=3&page=2&categories%5B0%5D=1175&categories%5B1%5D=1187&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -720,7 +720,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&exclude=103322%2C103154%2C103133&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&exclude=103322%2C103154%2C103133&_embed=
   response:
     body:
       string: '[{"id":103425,"date":"2021-07-08T07:21:55","date_gmt":"2021-07-08T07:21:55","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=103425"},"modified":"2021-07-08T08:48:29","modified_gmt":"2021-07-08T08:48:29","slug":"design-and-web-team-summary-2-july-2021","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/07\/08\/design-and-web-team-summary-2-july-2021\/","title":{"rendered":"Design
@@ -1963,7 +1963,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=96
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&exclude%5B0%5D=103322&exclude%5B1%5D=103154&exclude%5B2%5D=103133&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&exclude%5B0%5D=103322&exclude%5B1%5D=103154&exclude%5B2%5D=103133&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -2002,7 +2002,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=1&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=1&page=1&_embed=
   response:
     body:
       string: '[{"id":103425,"date":"2021-07-08T07:21:55","date_gmt":"2021-07-08T07:21:55","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=103425"},"modified":"2021-07-08T08:48:29","modified_gmt":"2021-07-08T08:48:29","slug":"design-and-web-team-summary-2-july-2021","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/07\/08\/design-and-web-team-summary-2-july-2021\/","title":{"rendered":"Design
@@ -2202,7 +2202,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=95
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=1&page=2&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=1&page=2&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)
@@ -2241,7 +2241,7 @@ interactions:
       User-Agent:
       - python-requests/2.25.1
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=30&page=1&exclude=103425&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=30&page=1&exclude=103425&_embed=
   response:
     body:
       string: '[{"id":103254,"date":"2021-06-28T09:52:01","date_gmt":"2021-06-28T09:52:01","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=103254"},"modified":"2021-06-28T10:31:34","modified_gmt":"2021-06-28T10:31:34","slug":"design-and-web-team-summary-28-june-2021","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2021\/06\/28\/design-and-web-team-summary-28-june-2021\/","title":{"rendered":"Design
@@ -6711,7 +6711,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=94
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=30&page=2&exclude%5B0%5D=103425&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=30&page=2&exclude%5B0%5D=103425&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestBlueprint.test_tag.yaml
+++ b/tests/cassettes/TestBlueprint.test_tag.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=
   response:
     body: {string: '[{"id":1239,"count":542,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/design\/","name":"Design","slug":"design","taxonomy":"post_tag","meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags\/1239"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/post_tag"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?tags=1239"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?tags=1239"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=12&page=1&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1807,7 +1807,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:37 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=12&page=2&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=12&page=2&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_tag_not_exist.yaml
+++ b/tests/cassettes/TestBlueprint.test_tag_not_exist.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=not-exist&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=not-exist&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlueprint.test_topic.yaml
+++ b/tests/cassettes/TestBlueprint.test_topic.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=
   response:
     body: {string: '[{"id":1239,"count":542,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/design\/","name":"Design","slug":"design","taxonomy":"post_tag","meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags\/1239"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/post_tag"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?tags=1239"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?tags=1239"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=12&page=1&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1808,7 +1808,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:37 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=12&page=2&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=12&page=2&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_topic_feed.yaml
+++ b/tests/cassettes/TestBlueprint.test_topic_feed.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=
   response:
     body: {string: '[{"id":1239,"count":542,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/design\/","name":"Design","slug":"design","taxonomy":"post_tag","meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags\/1239"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/post_tag"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?tags=1239"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?tags=1239"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags=1239&per_page=12&page=1&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1808,7 +1808,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:37 GMT']
       Keep-Alive: ['timeout=5, max=99']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=12&page=2&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?tags%5B0%5D=1239&per_page=12&page=2&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]

--- a/tests/cassettes/TestBlueprint.test_topic_feed_not_exists.yaml
+++ b/tests/cassettes/TestBlueprint.test_topic_feed_not_exists.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=not-exists&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=not-exists&_embed=
   response:
     body:
       string: '[]'

--- a/tests/cassettes/TestBlueprint.test_topic_not_exists.yaml
+++ b/tests/cassettes/TestBlueprint.test_topic_not_exists.yaml
@@ -11,7 +11,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=not-exists&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=not-exists&_embed=
   response:
     body:
       string: '[]'
@@ -71,7 +71,7 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=
   response:
     body:
       string: '[{"id":97853,"date":"2020-09-28T10:15:02","date_gmt":"2020-09-28T10:15:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=97853"},"modified":"2020-09-28T10:15:04","modified_gmt":"2020-09-28T10:15:04","slug":"osm-hackfest-mr9","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/09\/28\/osm-hackfest-mr9\/","title":{"rendered":"Canonical
@@ -1428,7 +1428,7 @@ interactions:
       Keep-Alive:
       - timeout=5, max=99
       Link:
-      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      - <https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
         rel="next"
       Server:
       - Apache/2.4.7 (Ubuntu)

--- a/tests/cassettes/TestWordpress.test_get_articles.yaml
+++ b/tests/cassettes/TestWordpress.test_get_articles.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=1&_embed=
   response:
     body: {string: '[{"id":96269,"date":"2020-06-09T09:26:02","date_gmt":"2020-06-09T09:26:02","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=96269"},"modified":"2020-06-09T13:47:07","modified_gmt":"2020-06-09T13:47:07","slug":"design-and-web-team-summary-9th-june-2020","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/06\/09\/design-and-web-team-summary-9th-june-2020\/","title":{"rendered":"Design
         and Web team summary \u2013 9th June 2020"},"content":{"rendered":"\n<p>The
@@ -1334,7 +1334,7 @@ interactions:
       Content-Type: [application/json; charset=UTF-8]
       Date: ['Tue, 09 Jun 2020 13:52:21 GMT']
       Keep-Alive: ['timeout=5, max=100']
-      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=true>;
+      Link: ['<https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?per_page=12&page=2&_embed=>;
           rel="next"']
       Server: [Apache/2.4.7 (Ubuntu)]
       Transfer-Encoding: [chunked]
@@ -1356,7 +1356,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=nonexistent-slug&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=nonexistent-slug&_embed=
   response:
     body: {string: '[]'}
     headers:
@@ -1388,7 +1388,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=testing-your-user-contract&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=testing-your-user-contract&_embed=
   response:
     body: {string: '[{"id":93920,"date":"2020-02-10T22:48:14","date_gmt":"2020-02-10T22:48:14","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/?p=93920"},"modified":"2020-02-10T23:32:02","modified_gmt":"2020-02-10T23:32:02","slug":"testing-your-user-contract","status":"publish","type":"post","link":"https:\/\/admin.insights.ubuntu.com\/2020\/02\/10\/testing-your-user-contract\/","title":{"rendered":"Testing
         your user contract"},"content":{"rendered":"\n<p>Whenever you write any code

--- a/tests/cassettes/TestWordpress.test_get_categories.yaml
+++ b/tests/cassettes/TestWordpress.test_get_categories.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories/1453?_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories/1453?_embed=
   response:
     body: {string: '{"id":1453,"count":1497,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/articles\/","name":"Articles","slug":"articles","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1453"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1453"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1453"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}'}
     headers:
@@ -37,7 +37,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=articles&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?slug=articles&_embed=
   response:
     body: {string: '[{"id":1453,"count":1497,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/articles\/","name":"Articles","slug":"articles","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1453"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1453"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1453"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -69,7 +69,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?per_page=100&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/categories?per_page=100&_embed=
   response:
     body: {string: '[{"id":1453,"count":1497,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/articles\/","name":"Articles","slug":"articles","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/1453"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=1453"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=1453"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}},{"id":2628,"count":102,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/canonical-news\/","name":"Canonical
         News","slug":"canonical-news","taxonomy":"category","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories\/2628"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/categories"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/category"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?categories=2628"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?categories=2628"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}},{"id":1172,"count":56,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/category\/case-studies\/","name":"Case

--- a/tests/cassettes/TestWordpress.test_get_groups.yaml
+++ b/tests/cassettes/TestWordpress.test_get_groups.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group/3367?_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group/3367?_embed=
   response:
     body: {string: '{"id":3367,"count":24,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/group\/ai\/","name":"AI","slug":"ai","taxonomy":"group","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group\/3367"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/group"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?group=3367"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/media?group=3367"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?group=3367"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}'}
     headers:
@@ -37,7 +37,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=ai&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/group?slug=ai&_embed=
   response:
     body: {string: '[{"id":3367,"count":24,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/group\/ai\/","name":"AI","slug":"ai","taxonomy":"group","parent":0,"meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group\/3367"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/group"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/group"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?group=3367"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/media?group=3367"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?group=3367"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:

--- a/tests/cassettes/TestWordpress.test_get_media.yaml
+++ b/tests/cassettes/TestWordpress.test_get_media.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/media/89203?_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/media/89203?_embed=
   response:
     body: {string: '{"id":89203,"date":"2019-05-16T11:46:48","date_gmt":"2019-05-16T11:46:48","guid":{"rendered":"https:\/\/admin.insights.ubuntu.com\/wp-content\/uploads\/barn-images-12223-unsplash-smaller.jpg"},"modified":"2019-05-16T11:46:54","modified_gmt":"2019-05-16T11:46:54","slug":"barn-images-12223-unsplash-smaller","status":"inherit","type":"attachment","link":"https:\/\/admin.insights.ubuntu.com\/2019\/05\/16\/introduction-to-snapcraft\/barn-images-12223-unsplash-smaller\/","title":{"rendered":"barn-images-12223-unsplash-smaller"},"author":597,"comment_status":"open","ping_status":"closed","template":"","meta":[],"topic":[],"group":[],"description":{"rendered":"<p
         class=\"attachment\"><a href=''https:\/\/admin.insights.ubuntu.com\/wp-content\/uploads\/b29e\/barn-images-12223-unsplash-smaller.jpg''><img

--- a/tests/cassettes/TestWordpress.test_get_tags.yaml
+++ b/tests/cassettes/TestWordpress.test_get_tags.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?slug=design&_embed=
   response:
     body: {string: '[{"id":1239,"count":542,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/design\/","name":"Design","slug":"design","taxonomy":"post_tag","meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags\/1239"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/post_tag"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?tags=1239"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?tags=1239"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}]'}
     headers:
@@ -40,7 +40,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags/1239?_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags/1239?_embed=
   response:
     body: {string: '{"id":1239,"count":542,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/design\/","name":"Design","slug":"design","taxonomy":"post_tag","meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags\/1239"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/post_tag"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?tags=1239"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?tags=1239"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}}'}
     headers:
@@ -70,7 +70,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?search=Design&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/tags?search=Design&_embed=
   response:
     body: {string: '[{"id":2720,"count":22,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/app-design\/","name":"app
         design","slug":"app-design","taxonomy":"post_tag","meta":[],"_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags\/2720"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/tags"}],"about":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/taxonomies\/post_tag"}],"wp:post_type":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/posts?tags=2720"},{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/event?tags=2720"}],"curies":[{"name":"wp","href":"https:\/\/api.w.org\/{rel}","templated":true}]}},{"id":2721,"count":5,"description":"","link":"https:\/\/admin.insights.ubuntu.com\/tag\/app-design-guides\/","name":"app

--- a/tests/cassettes/TestWordpress.test_get_users.yaml
+++ b/tests/cassettes/TestWordpress.test_get_users.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users/217?_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users/217?_embed=
   response:
     body: {string: '{"id":217,"name":"Canonical","url":"","description":"","link":"https:\/\/admin.insights.ubuntu.com\/author\/canonical\/","slug":"canonical","avatar_urls":{"24":"https:\/\/secure.gravatar.com\/avatar\/9d1f43af7ce4c818a532e9bb30f509e2?s=24&d=mm&r=g","48":"https:\/\/secure.gravatar.com\/avatar\/9d1f43af7ce4c818a532e9bb30f509e2?s=48&d=mm&r=g","96":"https:\/\/secure.gravatar.com\/avatar\/9d1f43af7ce4c818a532e9bb30f509e2?s=96&d=mm&r=g"},"meta":[],"user_job_title":"","user_website_title":"","user_google":"","user_twitter":"","user_facebook":"","user_photo":"","user_location":"","_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users\/217"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users"}]}}'}
     headers:
@@ -37,7 +37,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.22.0]
     method: GET
-    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=canonical&_embed=true
+    uri: https://admin.insights.ubuntu.com/wp-json/wp/v2/users?slug=canonical&_embed=
   response:
     body: {string: '[{"id":217,"name":"Canonical","url":"","description":"","link":"https:\/\/admin.insights.ubuntu.com\/author\/canonical\/","slug":"canonical","avatar_urls":{"24":"https:\/\/secure.gravatar.com\/avatar\/9d1f43af7ce4c818a532e9bb30f509e2?s=24&d=mm&r=g","48":"https:\/\/secure.gravatar.com\/avatar\/9d1f43af7ce4c818a532e9bb30f509e2?s=48&d=mm&r=g","96":"https:\/\/secure.gravatar.com\/avatar\/9d1f43af7ce4c818a532e9bb30f509e2?s=96&d=mm&r=g"},"meta":[],"user_job_title":"","user_website_title":"","user_google":"","user_twitter":"","user_facebook":"","user_photo":"","user_location":"","_links":{"self":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users\/217"}],"collection":[{"href":"https:\/\/admin.insights.ubuntu.com\/wp-json\/wp\/v2\/users"}]}}]'}
     headers:


### PR DESCRIPTION
Not entirely sure why, but from [5.4 WordPress API](https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_embed) doesn't require `POST /posts` to pass `&embed=` with truthy value, it can be an empty string, that will retrieve all embedded media by default. Why passing `true` doesn't? Not sure.

## QA
Code review note: because of the change in API param, all tests have been updated. You don't have to review the 40 other files.

https://ubuntu-com-13396.demos.haus/blog shows now the two missing new blog posts (not in the featured section but below that).
Check https://ubuntu.com/blog for a comparison, the latest 2 posts are missing.