### PR TITLE
Feat: added metadata description as one of return values

### DIFF
--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -181,17 +181,12 @@ class BlogAPI(Wordpress):
                         use_e_sharpen=True,
                     )
 
-        # extract meta description from yoast_head
-        yoast_head = article.get("yoast_head", "")
-        soup = BeautifulSoup(yoast_head, "html.parser")
-
-        meta_description_tag = soup.find("meta", attrs={"name": "description"})
-
-        if meta_description_tag:
-            meta_description = meta_description_tag.get("content", "")
-            article["meta_description"] = meta_description
-        else:
-            article["meta_description"] = article["excerpt"]["raw"] or ""
+        # extract meta description from yoast_head_json
+        yoast_head_json = article.get("yoast_head_json", {})
+        # if there is no meta description, use the excerpt
+        article["meta_description"] = yoast_head_json.get(
+            "description", article["excerpt"]["raw"]
+        )
 
         return article
 

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -159,16 +159,7 @@ class BlogAPI(Wordpress):
                 + article["image"]["source_url"]
                 + '" loading="lazy">'
             )
-        if "yoast_head" in article:
-            # extracting and parsing header metadata
-            yoast_head = article.get('yoast_head', '')
-            soup = BeautifulSoup(yoast_head, 'html.parser')
-            
-            meta_description_tag = soup.find('meta', attrs={'name': 'description'})
 
-            if meta_description_tag:
-                meta_description = meta_description_tag.get('content', '')
-                article["meta_description"] = meta_description
         if self.use_image_template:
             if "content" in article:
                 # apply image template for blog article images
@@ -189,6 +180,18 @@ class BlogAPI(Wordpress):
                         height=self.thumbnail_height,
                         use_e_sharpen=True,
                     )
+
+        # extract meta description from yoast_head
+        yoast_head = article.get("yoast_head", "")
+        soup = BeautifulSoup(yoast_head, "html.parser")
+
+        meta_description_tag = soup.find("meta", attrs={"name": "description"})
+
+        if meta_description_tag:
+            meta_description = meta_description_tag.get("content", "")
+            article["meta_description"] = meta_description
+        else:
+            article["meta_description"] = article["excerpt"]["raw"] or ""
 
         return article
 

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -159,7 +159,16 @@ class BlogAPI(Wordpress):
                 + article["image"]["source_url"]
                 + '" loading="lazy">'
             )
+        if "yoast_head" in article:
+            # extracting and parsing header metadata
+            yoast_head = article.get('yoast_head', '')
+            soup = BeautifulSoup(yoast_head, 'html.parser')
+            
+            meta_description_tag = soup.find('meta', attrs={'name': 'description'})
 
+            if meta_description_tag:
+                meta_description = meta_description_tag.get('content', '')
+                article["meta_description"] = meta_description
         if self.use_image_template:
             if "content" in article:
                 # apply image template for blog article images


### PR DESCRIPTION
## Done
- There was no param to reliably provide meta-description for the blogs and we needed it direly for SEO purposes.
- The code adds `meta_description` as one of return values for wp articles.

## QA
- Way to test is to use it with existing cases.
- Replace this code in `.venv` of ubuntu.com dev environment and try printing the article object to see if the value is being returned.
- Placing `{{ article }}` in templates/blog/article.html will help you print the object.
- Visit https://ubuntu-com-14644.demos.haus/blog/what-is-iot-device-management and see if value of `meta_description` is "Is that even a good meta""