### PR TITLE
[WD-23082] feat: add `total_posts` counter in `get_tag` response

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.4.5: Added `total_posts` in `get_tag` endpoint
 6.4.4: Reverted changes made in v6.4.2
 6.4.3: Added meta_description to articles
 6.4.2: Fix for blog posts not showing up 

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -370,6 +370,7 @@ class BlogViews:
         return {
             "current_page": int(page),
             "total_pages": int(total_pages),
+            "total_posts": metadata.get("total_posts", 0),
             "articles": articles,
             "title": self.blog_title,
             "tag": tag,

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -176,6 +176,7 @@ class BlogViews:
             tags=self.tag_ids + tag_ids,
             tags_exclude=self.excluded_tags,
             page=page,
+            per_page=self.per_page,
         )
 
         return {
@@ -238,6 +239,7 @@ class BlogViews:
             tags_exclude=self.excluded_tags,
             page=page,
             author=author["id"],
+            per_page=self.per_page,
         )
 
         return {
@@ -363,7 +365,10 @@ class BlogViews:
             return None
 
         articles, metadata = self.api.get_articles(
-            tags=[tag["id"]], tags_exclude=self.excluded_tags, page=page
+            tags=[tag["id"]],
+            tags_exclude=self.excluded_tags,
+            page=page,
+            per_page=self.per_page,
         )
         total_pages = metadata["total_pages"]
 

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -130,6 +130,7 @@ class BlogViews:
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
             page=page,
+            per_page=self.per_page,
             groups=[group.get("id", "")],
             categories=categories,
         )
@@ -217,6 +218,7 @@ class BlogViews:
             tags=self.tag_ids,
             tags_exclude=self.excluded_tags,
             page=page,
+            per_page=self.per_page,
             categories=[events["id"], webinars["id"]],
         )
         total_pages = metadata["total_pages"]


### PR DESCRIPTION
# Done
- add `total_posts` counter to the blog/tag page
- added per_page param to get_articles call in get_tag, get_author, get_topic and get_group endpoints

# QA
- Visit the following urls and verify all pages have 14 articles present by default
  - https://ubuntu-com-15214.demos.haus/blog/author/canonical
  - https://ubuntu-com-15214.demos.haus/blog/tag/design
  - https://ubuntu-com-15214.demos.haus/blog/topics/design
  - https://ubuntu-com-15214.demos.haus/blog/internet-of-things

- Visit the following urls, and verify all pages show the total number of posts in the header
  - https://ubuntu-com-15214.demos.haus/blog/author/canonical
  - https://ubuntu-com-15214.demos.haus/blog/tag/design
