### PR TITLE
feat: Allow passing of 'status' when fetching blogs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+6.6.0: Allow passing of 'status' when fetching blogs & added ability to add credentials 
 6.5.0: Blog Images can now pull their width and height from css styles
 6.4.6: Added `per_page` in `get_archives` endpoint
 6.4.5: Added `total_posts` in `get_tag` endpoint and `per_page` in `get_tag`, `get_author` and `get_index` endpoints

--- a/canonicalwebteam/blog/blog_api.py
+++ b/canonicalwebteam/blog/blog_api.py
@@ -40,6 +40,7 @@ class BlogAPI(Wordpress):
         groups=None,
         per_page=12,
         page=1,
+        status=None,
     ):
         articles, metadata = super().get_articles(
             tags,
@@ -53,6 +54,7 @@ class BlogAPI(Wordpress):
             groups,
             per_page,
             page,
+            status,
         )
 
         return (
@@ -60,8 +62,8 @@ class BlogAPI(Wordpress):
             metadata,
         )
 
-    def get_article(self, slug, tags=None, tags_exclude=None):
-        article = super().get_article(slug, tags, tags_exclude)
+    def get_article(self, slug, tags=None, tags_exclude=None, status=None):
+        article = super().get_article(slug, tags, tags_exclude, status)
 
         if not article:
             return {}

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -18,6 +18,7 @@ class BlogViews:
         blog_path="blog",
         feed_description=None,
         per_page=12,
+        status=None,
     ):
         self.api = api
         self.tag_ids = tag_ids
@@ -26,6 +27,7 @@ class BlogViews:
         self.blog_path = blog_path.strip("/")
         self.feed_description = feed_description or f"{blog_title} feed"
         self.per_page = per_page
+        self.status = status or ["publish"]
 
     def get_index(self, page=1, category_slug=""):
         categories = []
@@ -64,6 +66,7 @@ class BlogViews:
             page=page,
             per_page=self.per_page,
             categories=categories,
+            status=self.status,
         )
 
         return {
@@ -94,7 +97,7 @@ class BlogViews:
         return feed.rss_str()
 
     def get_article(self, slug):
-        article = self.api.get_article(slug, self.tag_ids, self.excluded_tags)
+        article = self.api.get_article(slug, self.tag_ids, self.excluded_tags, self.status)
 
         if not article:
             return {}
@@ -372,6 +375,7 @@ class BlogViews:
             tags_exclude=self.excluded_tags,
             page=page,
             per_page=self.per_page,
+            status=self.status,
         )
         total_pages = metadata["total_pages"]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.blog",
-    version="6.5.0",
+    version="6.6.0",
     description=("Flask extension to add a nice blog to your website"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Done

- Allow passing of 'status' when fetching blogs. This means we can specify what type of blog to fetch. These can be publish, future, draft, pending, private. 

## QA

- Open the demo
- See that the blog posts loads
- Confirm it is a [draft blog](https://admin.insights.ubuntu.com/wp-admin/post.php?post=126553&action=edit)

## Issue

https://warthogs.atlassian.net/browse/WD-24696